### PR TITLE
fix typo for undefined comparison in statement

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -746,7 +746,7 @@ function makeBuyOffer(theProduct,handlerInput){
 }
 
 function shouldUpsell(handlerInput) {
-	if (handlerInput.requestEnvelope.request.intent == undefined){
+	if (handlerInput.requestEnvelope.request.intent === undefined){
 		//If the last intent was Connections.Response, do not upsell
 		return false;    
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update operator used when using undefined to make comparison in an 'if' statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
