### PR TITLE
fix typo in instructions to add One-Time Purchase

### DIFF
--- a/instructions/3-create-isp.md
+++ b/instructions/3-create-isp.md
@@ -18,7 +18,7 @@ This sample implements a "One-Time Purchase" product called "Greeting Pack", whi
 1. Click **Create in-skill product**.
 1. Enter a Reference name.  This is code-friendly name you want to assign to your in-skill product.  For this sample, the code is expecting the reference name `Greetings_Pack`.
     > Be sure to enter all the reference names exactly as provided.  They are used in the sample code and it won't work properly if the name does not match exactly.
-1. Choose **Subscription**.
+1. Choose **One-Time Purchase**.
 1. Click **Create in-skill product**.
 1. On the **Distribution** sub-section, enter the following details for the subscription:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On Instructions to create ISP Products, under the section <Create a "One-Time Purchase">, Step 4 incorrectly states to select 'Subscription' as product. This should be an 'One-Time Purchase' Product.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
