### PR TITLE
add tellmemore* intents in interaction model

### DIFF
--- a/models/en-US.json
+++ b/models/en-US.json
@@ -43,6 +43,14 @@
                   ]
               },
               {
+                "name": "TellMeMoreAboutGreetingsPackIntent",
+                "slots": [],
+                "samples": [
+                    "tell me more about greetings pack",
+                    "what is greetings pack"
+                ]
+              },
+              {
                   "name": "BuyGreetingsPackIntent",
                   "slots": [],
                   "samples": [
@@ -62,6 +70,14 @@
                       "what have I purchased",
                       "what have I bought"
                   ]
+              },
+              {
+                "name": "TellMeMoreAboutPremiumSubscription",
+                "slots": [],
+                "samples": [
+                    "tell me more about premium subscription",
+                    "what is premium subscription"
+                ]
               },
               {
                   "name": "BuyPremiumSubscriptionIntent",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backend code (lambda) does have handlers for Intents which are not available in Interaction Model.
The objective of this PR is to add the missing intents in the Interaction Model.
Here are the following two handlers :

- TellMeMoreAboutPremiumSubscriptionIntentHandler
Missing Intent : TellMeMoreAboutPremiumSubscription
(added by this PR)

- TellMeMoreAboutGreetingsPackIntentHandler
Missing Intent : TellMeMoreAboutGreetingsPackIntent
(added by this PR)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
